### PR TITLE
MNT Namespace DAGs to separate them from the "dev" repo

### DIFF
--- a/dags/estimate_cell.py
+++ b/dags/estimate_cell.py
@@ -6,6 +6,7 @@ from btx.plugins.jid import JIDSlurmOperator
 # DAG SETUP
 description='BTX index and determine cell DAG'
 dag_name = os.path.splitext(os.path.basename(__file__))[0]
+dag_name = f"slac_lcls_{dag_name}"
 
 dag = DAG(
     dag_name,

--- a/dags/index_run.py
+++ b/dags/index_run.py
@@ -6,6 +6,7 @@ from btx.plugins.jid import JIDSlurmOperator
 # DAG SETUP
 description='BTX index run DAG'
 dag_name = os.path.splitext(os.path.basename(__file__))[0]
+dag_name = f"slac_lcls_{dag_name}"
 
 dag = DAG(
     dag_name,

--- a/dags/merge.py
+++ b/dags/merge.py
@@ -6,6 +6,7 @@ from btx.plugins.jid import JIDSlurmOperator
 # DAG SETUP
 description='BTX process SFX DAG'
 dag_name = os.path.splitext(os.path.basename(__file__))[0]
+dag_name = f"slac_lcls_{dag_name}"
 
 dag = DAG(
     dag_name,

--- a/dags/optimize_geometry.py
+++ b/dags/optimize_geometry.py
@@ -6,6 +6,7 @@ from btx.plugins.jid import JIDSlurmOperator
 # DAG SETUP
 description='BTX optimize geometry DAG'
 dag_name = os.path.splitext(os.path.basename(__file__))[0]
+dag_name = f"slac_lcls_{dag_name}"
 
 dag = DAG(
     dag_name,

--- a/dags/process_saxs.py
+++ b/dags/process_saxs.py
@@ -5,6 +5,7 @@ from btx.plugins.jid import JIDSlurmOperator
 
 description='BTX process SAXS DAG'
 dag_name = os.path.splitext(os.path.basename(__file__))[0]
+dag_name = f"slac_lcls_{dag_name}"
 
 dag = DAG(
     dag_name,

--- a/dags/process_sfx.py
+++ b/dags/process_sfx.py
@@ -6,6 +6,7 @@ from btx.plugins.jid import JIDSlurmOperator
 # DAG SETUP
 description='BTX process SFX DAG'
 dag_name = os.path.splitext(os.path.basename(__file__))[0]
+dag_name = f"slac_lcls_{dag_name}"
 
 dag = DAG(
     dag_name,

--- a/dags/run_stats.py
+++ b/dags/run_stats.py
@@ -6,6 +6,7 @@ from btx.plugins.jid import JIDSlurmOperator
 # DAG SETUP
 description='BTX optimize geometry DAG'
 dag_name = os.path.splitext(os.path.basename(__file__))[0]
+dag_name = f"slac_lcls_{dag_name}"
 
 dag = DAG(
     dag_name,

--- a/dags/setup_metrology.py
+++ b/dags/setup_metrology.py
@@ -6,6 +6,7 @@ from btx.plugins.jid import JIDSlurmOperator
 # DAG SETUP
 description='BTX setup metrology DAG'
 dag_name = os.path.splitext(os.path.basename(__file__))[0]
+dag_name = f"slac_lcls_{dag_name}"
 
 dag = DAG(
     dag_name,

--- a/dags/stream_analysis.py
+++ b/dags/stream_analysis.py
@@ -6,6 +6,7 @@ from btx.plugins.jid import JIDSlurmOperator
 # DAG SETUP
 description='BTX stream analysis DAG'
 dag_name = os.path.splitext(os.path.basename(__file__))[0]
+dag_name = f"slac_lcls_{dag_name}"
 
 dag = DAG(
     dag_name,

--- a/dags/test.py
+++ b/dags/test.py
@@ -6,6 +6,7 @@ from btx.plugins.jid import JIDSlurmOperator
 # DAG SETUP
 description='BTX test DAG'
 dag_name = os.path.splitext(os.path.basename(__file__))[0]
+dag_name = f"slac_lcls_{dag_name}"
 
 dag = DAG(
     dag_name,

--- a/dags/test2.py
+++ b/dags/test2.py
@@ -6,6 +6,7 @@ from btx.plugins.jid import JIDSlurmOperator
 # DAG SETUP
 description='BTX test DAG'
 dag_name = os.path.splitext(os.path.basename(__file__))[0]
+dag_name = f"slac_lcls_{dag_name}"
 
 dag = DAG(
     dag_name,

--- a/dags/update_mask.py
+++ b/dags/update_mask.py
@@ -6,6 +6,7 @@ from btx.plugins.jid import JIDSlurmOperator
 # DAG SETUP
 description='BTX update mask DAG'
 dag_name = os.path.splitext(os.path.basename(__file__))[0]
+dag_name = f"slac_lcls_{dag_name}"
 
 dag = DAG(
     dag_name,

--- a/dags/wrapup_sample.py
+++ b/dags/wrapup_sample.py
@@ -6,6 +6,7 @@ from btx.plugins.jid import JIDSlurmOperator
 # DAG SETUP
 description='BTX wrap-up sample DAG'
 dag_name = os.path.splitext(os.path.basename(__file__))[0]
+dag_name = f"slac_lcls_{dag_name}"
 
 dag = DAG(
     dag_name,

--- a/scripts/elog_trigger.py
+++ b/scripts/elog_trigger.py
@@ -56,7 +56,7 @@ if __name__ == '__main__':
             "user": getpass.getuser(),
             "parameters": {
                 "config_file": args.config,
-                "dag": args.dag,
+                "dag": f"slac_lcls_{args.dag}",
                 "queue": args.queue,
                 "ncores": args.ncores,
                 "experiment_name": experiment_name,


### PR DESCRIPTION
Change Log
-----------------
- DAGs in this repo now have "dag ids" which are prefixed by `slac_lcls_`. This allows both `stable` and `dev` DAGs to coexist without collision since Airflow flattens the folder structure when constructing the DAG list.
- The `elog_trigger` script automatically adds the `slac_lcls_` prefix to the DAG name (in this repo). In this way, DAGs can be called identically from the eLog/commandline using either the `stable` or `dev` repositories. E.g if you ask for the `process_sfx` DAG, it will request the `slac_lcls_process_sfx` DAG in this (`stable`) repo.
- The corresponding prefixed/namespaced DAGs have been activated in Airflow

Screenshot
-----------------
![image](https://github.com/slac-lcls/btx/assets/18701604/4e413749-79ad-4d13-81e7-a880b4a3f42a)
