### PR TITLE
BUG Fixes for using SLURM Reservations and Calling Stable DAGs

### DIFF
--- a/btx/diagnostics/geoptimizer.py
+++ b/btx/diagnostics/geoptimizer.py
@@ -19,9 +19,10 @@ class Geoptimizer:
     Class for refining the geometry. 
     """
     def __init__(self, queue, task_dir, scan_dir, runs, input_geom, dx_scan, dy_scan, dz_scan,
-                 slurm_account="lcls"
+                 slurm_account="lcls", slurm_reservation=""
     ):
         self.slurm_account = slurm_account
+        self.slurm_reservation = slurm_reservation
         self.queue = queue # queue to submit jobs to, str
         self.task_dir = task_dir # path to indexing directory, str
         self.scan_dir = scan_dir # path to scan directory, str
@@ -118,7 +119,7 @@ class Geoptimizer:
                                geom=gfile, cell=cell_file, int_rad=params.int_radius, methods=params.methods, tolerance=params.tolerance, no_revalidate=params.no_revalidate, 
                                multi=params.multi, profile=params.profile, queue=self.queue, ncores=params.get('ncores') if params.get('ncores') is not None else 64,
                                time=params.get('time') if params.get('time') is not None else '1:00:00',
-                               slurm_account=self.slurm_account)
+                               slurm_account=self.slurm_account, slurm_reservation=self.slurm_reservation)
                 idxr.tmp_exe = jobfile
                 idxr.stream = stream
                 idxr.launch(addl_command=f"echo {jobname} | tee -a {statusfile}\n",
@@ -157,7 +158,8 @@ class Geoptimizer:
                                    cell_out=os.path.join(celldir, f"g{num}.cell"),
                                    cell_ref=params.get('ref_cell'),
                                    addl_command=f"echo {jobname} | tee -a {statusfile}\n",
-                                   slurm_account=self.slurm_account
+                                   slurm_account=self.slurm_account,
+                                   slurm_reservation=self.slurm_reservation
             )
             jobnames.append(jobname)
             time.sleep(self.frequency)
@@ -195,7 +197,8 @@ class Geoptimizer:
             
             stream_to_mtz = StreamtoMtz(instream, params.symmetry, mergedir, cellfile, queue=self.queue, tmp_exe=jobfile,
                                         ncores=params.get('ncores') if params.get('ncores') is not None else 16,
-                                        slurm_account=self.slurm_account
+                                        slurm_account=self.slurm_account,
+                                        slurm_reservation=self.slurm_reservation
             )
             stream_to_mtz.cmd_partialator(iterations=params.iterations, model=params.model, 
                                           min_res=params.get('min_res'), push_res=params.get('push_res'))

--- a/btx/interfaces/imtz.py
+++ b/btx/interfaces/imtz.py
@@ -141,7 +141,8 @@ def f2mtz_command(outmtz):
     
     return command
 
-def run_dimple(mtz, pdb, outdir, queue='milano', ncores=16, anomalous=False, slurm_account="lcls"):
+def run_dimple(mtz, pdb, outdir, queue='milano', ncores=16, anomalous=False, slurm_account="lcls",
+               slurm_reservation=""):
     """
     Run dimple to solve the structure: 
     http://ccp4.github.io/dimple/.
@@ -156,6 +157,10 @@ def run_dimple(mtz, pdb, outdir, queue='milano', ncores=16, anomalous=False, slu
         output directory for storing results
     anomalous : bool
         if True, generate an anomalous difference map
+    slurm_account : str
+        SLURM account to use. Default: "lcls"
+    slurm_reservation : str
+        SLURM reservation to use, if one. Default: ""
     """
     os.makedirs(outdir, exist_ok=True)
     command = f"dimple {mtz} {pdb} {outdir}"
@@ -167,7 +172,8 @@ def run_dimple(mtz, pdb, outdir, queue='milano', ncores=16, anomalous=False, slu
                       ncores=ncores, 
                       jobname=f'dimple', 
                       queue=queue,
-                      account=slurm_account)
+                      account=slurm_account,
+                      reservation=slurm_reservation)
     js.write_header()
     js.write_main(command + "\n", dependencies=['ccp4'])
     js.clean_up()

--- a/btx/interfaces/ischeduler.py
+++ b/btx/interfaces/ischeduler.py
@@ -9,7 +9,8 @@ logger = logging.getLogger(__name__)
 class JobScheduler:
 
     def __init__(self, jobfile, logdir='./', jobname='btx',
-                 account='lcls', queue='ffbh3q', ncores=1, time='0:30:00'):
+                 account='lcls', queue='ffbh3q', ncores=1, time='0:30:00',
+                 reservation=""):
         self.manager = 'SLURM'
         self.jobfile = jobfile
         self.logdir = logdir
@@ -18,6 +19,7 @@ class JobScheduler:
         self.queue = queue
         self.ncores = ncores
         self.time = time
+        self.reservation=reservation
         self._data_systems_management()
 
     def _data_systems_management(self):
@@ -90,6 +92,10 @@ class JobScheduler:
         if self.account is not None and facility == 'S3DF':
             with open(self.jobfile, 'a') as jfile:
                 jfile.write(f"#SBATCH -A {self.account}\n\n")
+
+        if self.reservation and facility  == "S3DF":
+            with open(self.jobfile, 'a') as jfile:
+                jfile.write(f"#SBATCH --reservation {self.reservation}\n\n")
 
     def _write_dependencies(self, dependencies):
         """ Source dependencies."""

--- a/btx/interfaces/istream.py
+++ b/btx/interfaces/istream.py
@@ -75,7 +75,10 @@ class StreamInterface:
                 if key == 'n_crystal':
                     stream_data[key] = [np.array(arr) for arr in stream_data[key]]
                     for narr in range(1, len(stream_data[key])):
-                        stream_data[key][narr] += stream_data[key][narr-1][-1]+1
+                        if stream_data[key][narr-1].any():
+                            stream_data[key][narr] += stream_data[key][narr-1][-1]+1
+                        else:
+                            stream_data[key][narr] += 0
                 stream_data[key] = np.concatenate(np.array(stream_data[key], dtype=object))
                 if key in ['n_crystal','n_chunk', 'n_crystal_cell', 'n_lattice', 'image_num', 'h', 'k', 'l']:
                     stream_data[key] = stream_data[key].astype(int)

--- a/btx/interfaces/istream.py
+++ b/btx/interfaces/istream.py
@@ -591,7 +591,7 @@ def cluster_cell_params(cell, out_clusters, out_cell, in_cell=None, eps=5, min_s
 
 def launch_stream_analysis(in_stream, out_stream, fig_dir, tmp_exe, queue, ncores, 
                            cell_only=False, cell_out=None, cell_ref=None, addl_command=None,
-                           slurm_account="lcls"):
+                           slurm_account="lcls", slurm_reservation=""):
                            
     """
     Launch stream analysis task using iScheduler.
@@ -618,6 +618,10 @@ def launch_stream_analysis(in_stream, out_stream, fig_dir, tmp_exe, queue, ncore
         CrystFEL cell file to copy symmetry from
     addl_command : str
         additional command to add to end of job to launch
+    slurm_account : str
+        SLURM account to use. Default: "lcls"
+    slurm_reservation : str
+        SLURM reservation to use, if one. Default: ""
     """
     ncores_max = len(glob.glob(in_stream))
     if ncores > ncores_max:
@@ -634,7 +638,7 @@ def launch_stream_analysis(in_stream, out_stream, fig_dir, tmp_exe, queue, ncore
             command += f" --cell_ref={cell_ref}"
         
     js = JobScheduler(tmp_exe, ncores=ncores, jobname=f'stream_analysis', queue=queue,
-                      account=slurm_account)
+                      account=slurm_account, reservation=slurm_reservation)
     js.write_header()
     js.write_main(f"{command}\n")
     js.write_main(f"cat {in_stream} > {out_stream}\n")

--- a/btx/misc/metrology.py
+++ b/btx/misc/metrology.py
@@ -1,6 +1,7 @@
 import numpy as np
 import os, sys
 import argparse
+import shutil
 from psgeom import camera, sensors
 from btx.interfaces.ipsana import PsanaInterface
 
@@ -24,12 +25,7 @@ def retrieve_from_mrxv(det_type, out_geom, mrxv_path='/cds/sw/package/autosfx/mr
     except:
         sys.exit("Detector type not yet available in mrxv")
 
-    if det_type == 'epix10k2M':
-        geom = camera.CompoundAreaCamera.from_crystfel_file(in_geom, element_type=sensors.Epix10kaSegment)
-    else:
-        geom = camera.CompoundAreaCamera.from_crystfel_file(in_geom)
-
-    geom.to_crystfel_file(out_geom)
+    shutil.copyfile(in_geom, out_geom)
 
 def modify_crystfel_coffset_res(input_file, output_file, coffset, res):
     """

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -17,7 +17,8 @@ class Indexer:
 
     def __init__(self, exp, run, det_type, tag, taskdir, geom, cell=None, int_rad='4,5,6', methods='mosflm',
                  tolerance='5,5,5,1.5', tag_cxi=None, no_revalidate=True, multi=True, profile=True,
-                 ncores=64, queue='milano', time='1:00:00', *, mpi_init = False, slurm_account="lcls"):
+                 ncores=64, queue='milano', time='1:00:00', *, mpi_init = False, slurm_account="lcls",
+                 slurm_reservation=""):
 
         if mpi_init:
             from mpi4py import MPI
@@ -51,6 +52,7 @@ class Indexer:
         self.queue = queue # str, submission queue
         self.time = time # str, time limit
         self.slurm_account = slurm_account
+        self.slurm_reservation = slurm_reservation
         self._retrieve_paths()
 
     def _retrieve_paths(self):
@@ -100,7 +102,8 @@ class Indexer:
 
         js = JobScheduler(self.tmp_exe, ncores=self.ncores,
                           jobname=f'idx_r{self.run:04}', queue=self.queue,
-                          time=self.time, account=self.slurm_account)
+                          time=self.time, account=self.slurm_account,
+                          reservation=self.slurm_reservation)
         js.write_header()
         js.write_main(command, dependencies=['crystfel'] + self.methods.split(','))
         js.clean_up()

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -88,7 +88,7 @@ class Indexer:
             if False, do not create summary files / report to elog
         """     
         command=f"indexamajig -i {self.lst} -o {self.stream} -j {self.ncores} -g {self.geom} --peaks=cxi --int-rad={self.rad} --indexing={self.methods} --tolerance={self.tolerance}"
-        if self.cell is not None: command += f' --pdb={self.cell}'
+        if self.cell: command += f' --pdb={self.cell}'
         if self.no_revalidate: command += ' --no-revalidate'
         if self.multi: command += ' --multi'
         if self.profile: command += ' --profile'

--- a/btx/processing/merge.py
+++ b/btx/processing/merge.py
@@ -20,7 +20,7 @@ class StreamtoMtz:
     """
     
     def __init__(self, input_stream, symmetry, taskdir, cell, ncores=16, queue='milano', tmp_exe=None, mtz_dir=None, anomalous=False,
-                 mpi_init=False, slurm_account="lcls"):
+                 mpi_init=False, slurm_account="lcls", slurm_reservation=""):
         self.stream = input_stream # file of unmerged reflections, str
         self.symmetry = symmetry # point group symmetry, str
         self.taskdir = taskdir # path for storing output, str
@@ -28,6 +28,7 @@ class StreamtoMtz:
         self.ncores = ncores # int, number of cores for merging
         self.queue = queue # cluster to submit job to
         self.slurm_account = slurm_account
+        self.slurm_reservation = slurm_reservation
         self.mtz_dir = mtz_dir # directory to which to transfer mtz
         self.anomalous = anomalous # whether to separate Bijovet pairs
         self._set_up(tmp_exe)
@@ -63,7 +64,8 @@ class StreamtoMtz:
         if tmp_exe is None:
             tmp_exe = os.path.join(self.taskdir ,f'merge.sh')
         self.js = JobScheduler(tmp_exe, ncores=self.ncores, jobname=f'merge',
-                               queue=self.queue, account=self.slurm_account)
+                               queue=self.queue, account=self.slurm_account,
+                               reservation=self.slurm_reservation)
         self.js.write_header()
 
         # retrieve paths

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -51,7 +51,7 @@ index:
   time: '1:30:00'
   ncores: 64
   tag: 'S1'
-  tag_cxi: ''
+  tag_cxi: 'S1'
   int_radius: '3,4,5'
   methods: 'mosflm'
   tolerance: '5,5,5,1.5'

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -11,7 +11,7 @@ setup:
 elog_display:
 
 fetch_mask:
-  dataset: '/data/data'
+  dataset: '/entry_1/data_1/mask' # Rayonix - switch to /data/data for other det
 
 fetch_geom:
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -4,7 +4,7 @@ setup:
   root_dir: ''
   exp: ''
   run: 5
-  det_type: 'epix10k2M'
+  det_type: 'Rayonix'
   cell: ''
 
 elog_display:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -33,7 +33,7 @@ opt_geom:
   threshold: 1000000
 
 find_peaks:
-  tag: ''
+  tag: 'S1'
   psana_mask: False
   min_peaks: 10
   max_peaks: 2048
@@ -50,7 +50,7 @@ find_peaks:
 index:
   time: '1:30:00'
   ncores: 64
-  tag: ''
+  tag: 'S1'
   tag_cxi: ''
   int_radius: '3,4,5'
   methods: 'mosflm'
@@ -61,12 +61,12 @@ index:
   cell: ''
 
 stream_analysis:
-  tag: ''
+  tag: 'S1'
   cell_only: False
   ncores: 6
 
 merge:
-  tag: ''
+  tag: 'S1'
   symmetry: '4/mmm_uac'
   iterations: 1
   model: 'unity'
@@ -75,5 +75,5 @@ merge:
   highres: 2.5
 
 solve:
-  tag: ''
+  tag: 'S1'
   pdb: ''

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,6 +1,7 @@
 setup:
   queue: 'milano'
   account: ''
+  reservation: ''
   root_dir: ''
   exp: ''
   run: 5

--- a/scripts/elog_submit.sh
+++ b/scripts/elog_submit.sh
@@ -23,6 +23,8 @@ $(basename "$0"):
       Experiment Name
     -r|--run_number
       Run Number
+    -R|--reservation
+      SLURM reservation (optional).
     -t|--task
       Task name
 EOF
@@ -73,6 +75,11 @@ do
       shift
       shift
       ;;
+    -R|--reservation)
+      RESERVATION="$2"
+      shift
+      shift
+      ;;
     -t|--task)
       TASK="$2"
       shift
@@ -91,6 +98,12 @@ fi
 
 if [[ -z ${FACILITY} ]]; then
     echo "Facility not provided, defaulting to S3DF."
+fi
+
+if [[ -n ${RESERVATION} ]]; then
+    SBATCH_CMD_RESERVATION="#SBATCH --reservation ${RESERVATION}"
+else
+    SBATCH_CMD_RESERVATION=""
 fi
 
 SLURM_ACCOUNT=${SLURM_ACCOUNT:='lcls'}
@@ -173,6 +186,7 @@ ${SBATCH_CMD_ACCOUNT}
 #SBATCH --exclusive
 #SBATCH --job-name ${TASK}
 #SBATCH --ntasks=${CORES}
+${SBATCH_CMD_RESERVATION}
 
 source "${ANA_CONDA_MANAGE}psconda.sh"
 conda env list | grep '*'

--- a/scripts/elog_trigger.py
+++ b/scripts/elog_trigger.py
@@ -25,7 +25,14 @@ if __name__ == '__main__':
     parser.add_argument(
         "-a",
         "--account",
-        help="S3DF account to use, including repo and/or reservation.",
+        help="S3DF account to use, including repo.",
+        default=""
+    )
+    parser.add_argument(
+        "-r",
+        "--reservation",
+        type=str,
+        help="SLURM reservation to use (optional).",
         default=""
     )
     args = parser.parse_args()
@@ -62,7 +69,7 @@ if __name__ == '__main__':
                 "experiment_name": experiment_name,
                 "run_number": run_num,
                 "account": account
-            }
+            } | ({"reservation": args.reservation} if args.reservation else {})
         }
     }
     

--- a/scripts/elog_trigger.py
+++ b/scripts/elog_trigger.py
@@ -51,6 +51,18 @@ if __name__ == '__main__':
 
     account = args.account if args.account else f"lcls:{experiment_name}"
 
+    params = {
+        "config_file": args.config,
+        "dag": f"slac_lcls_{args.dag}",
+        "queue": args.queue,
+        "ncores": args.ncores,
+        "experiment_name": experiment_name,
+        "run_number": run_num,
+        "account": account
+    }
+    if args.reservation:
+        params.update({"reservation": args.reservation})
+
     dag_run_data = {
         "dag_run_id": str(uuid.uuid4()),
         "conf": {
@@ -61,18 +73,10 @@ if __name__ == '__main__':
             "ARP_LOCATION": 'S3DF', #os.environ["ARP_LOCATION"],
             "Authorization": auth_header,
             "user": getpass.getuser(),
-            "parameters": {
-                "config_file": args.config,
-                "dag": f"slac_lcls_{args.dag}",
-                "queue": args.queue,
-                "ncores": args.ncores,
-                "experiment_name": experiment_name,
-                "run_number": run_num,
-                "account": account
-            } | ({"reservation": args.reservation} if args.reservation else {})
+            "parameters": params
         }
     }
-    
+
     resp = requests.post(airflow_s3df + f"api/v1/dags/slac_lcls_{args.dag}/dagRuns", json=dag_run_data, auth=HTTPBasicAuth('btx', 'btx'))
     resp.raise_for_status()
     print(resp.text)

--- a/scripts/elog_trigger.py
+++ b/scripts/elog_trigger.py
@@ -66,7 +66,7 @@ if __name__ == '__main__':
         }
     }
     
-    resp = requests.post(airflow_s3df + f"api/v1/dags/{args.dag}/dagRuns", json=dag_run_data, auth=HTTPBasicAuth('btx', 'btx'))
+    resp = requests.post(airflow_s3df + f"api/v1/dags/slac_lcls_{args.dag}/dagRuns", json=dag_run_data, auth=HTTPBasicAuth('btx', 'btx'))
     resp.raise_for_status()
     print(resp.text)
 

--- a/scripts/setup_btx.py
+++ b/scripts/setup_btx.py
@@ -123,7 +123,7 @@ if __name__ == "__main__":
         main_workflow: Dict[str, str] = {
             "name": "run_btx",
             "executable": executable,
-            "trigger": "START_OF_RUN",
+            "trigger": "END_OF_RUN",
             "location": "S3DF",
             "parameters": params
         }

--- a/scripts/setup_btx.sh
+++ b/scripts/setup_btx.sh
@@ -98,6 +98,7 @@ fi
 ACCOUNT=${ACCOUNT:="lcls:${EXP}"}
 CORES=${CORES:=64}
 QUEUE=${QUEUE:="milano"}
+RESERVATION=${RESERVATION:="lcls:onshift"}
 WORKFLOW=${WORKFLOW:="sfx"}
 
 BTX_DIR="/sdf/group/lcls/ds/tools/btx/stable"

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -100,7 +100,8 @@ def run_analysis(config):
                       queue=setup.queue,
                       ncores=task.ncores,
                       jobname=f'ra_{setup.run:04}',
-                      account=setup.account)
+                      account=setup.account,
+                      reservation=setup.reservation)
     js.write_header()
     js.write_main(f"{command}\n", dependencies=['psana'])
     js.clean_up()
@@ -370,7 +371,8 @@ def refine_geometry(config, task=None):
                         task.dx,
                         task.dy,
                         task.dz,
-                        slurm_account=setup.account
+                        slurm_account=setup.account,
+                        slurm_reservation=setup.reservation
     )
     geopt.launch_indexing(setup.exp, setup.det_type, config.index, cell_file)
     geopt.launch_stream_wrangling(config.stream_analysis)

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -270,7 +270,8 @@ def stream_analysis(config):
                            cell_only=task.get('cell_only') if task.get('cell_only') is not None else False,
                            cell_out=os.path.join(setup.root_dir, 'cell', f'{task.tag}.cell'),
                            cell_ref=task.get('ref_cell'),
-                           slurm_account=setup.account)
+                           slurm_account=setup.account,
+                           slurm_reservation=setup.reservation)
     logger.info(f'Stream analysis launched')
 
 def determine_cell(config):

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -195,7 +195,8 @@ def index(config):
     indexer_obj = Indexer(exp=config.setup.exp, run=config.setup.run, det_type=config.setup.det_type, tag=task.tag, tag_cxi=task.get('tag_cxi'), taskdir=taskdir,
                           geom=geom_file, cell=task.get('cell'), int_rad=task.int_radius, methods=task.methods, tolerance=task.tolerance, no_revalidate=task.no_revalidate,
                           multi=task.multi, profile=task.profile, queue=setup.get('queue'), ncores=task.get('ncores') if task.get('ncores') is not None else 64,
-                          time=task.get('time') if task.get('time') is not None else '1:00:00', mpi_init = False, slurm_account=setup.account)
+                          time=task.get('time') if task.get('time') is not None else '1:00:00', mpi_init = False, slurm_account=setup.account,
+                          slurm_reservation=setup.reservation)
     logger.debug(f'Generating indexing executable for run {setup.run} of {setup.exp}...')
     indexer_obj.launch()
     logger.info(f'Indexing launched!')

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -334,7 +334,8 @@ def solve(config):
                queue=setup.get('queue'),
                ncores=task.get('ncores') if task.get('ncores') is not None else 16,
                anomalous=task.get('anomalous') if task.get('anomalous') is not None else False,
-               slurm_account=setup.account)
+               slurm_account=setup.account,
+               slurm_reservation=setup.reservation)
     logger.info(f'Dimple launched!')
 
 def refine_geometry(config, task=None):

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -311,7 +311,7 @@ def merge(config):
                                 ncores=task.get('ncores') if task.get('ncores') is not None else 16,
                                 mtz_dir=os.path.join(setup.root_dir, "solve", f"{task.tag}"),
                                 anomalous=task.get('anomalous') if task.get('anomalous') is not None else False,
-                                slurm_account=setup.account)
+                                slurm_account=setup.account, slurm_reservation=setup.reservation)
     stream_to_mtz.cmd_partialator(iterations=task.iterations, model=task.model,
                                   min_res=task.get('min_res'), push_res=task.get('push_res'), max_adu=task.get('max_adu'))
     for ns in [1, task.nshells]:


### PR DESCRIPTION
Change Log
------------------
- [x] Switch workflows to be triggered at `END_OF_RUN` when they are setup by the automated setup scripts.
- [x] Add a reservation parameter option to `elog_trigger`
- [x] Add a reservation parameter option to `elog_submit`
- [x] Add a reservation parameter option to `ischeduler`
- Have tasks using `ischeduler` properly propagate reservations to secondary SLURM jobs
  - [x] `index`
  - [x]  `stream_analysis`
  - [x]  `merge`
  - [x]  `solve`
  - [x]  `run_analysis`
  - [x]  `refine_geometry`
  - [x]  `refine_center`
  - [x]  `refine_distance`
- [x] Add `reservation` parameter under `setup` in the default YAML for tasks that need `ischeduler`
- Change certain defaults when using the setup scripts:
  - [x] Make Rayonix the default detector in the config YAML copied by `setup_btx.sh`
  - [x] Make use of the `lcls:onshift` reservation the default. This makes sense since we usually want to run during the actual beamtime.
  - [x] Switch default config YAML to use a _tag_ of `S1` since the empty _tag_ `''` can be problematic for some tasks
- [x] Call the appropriate "stable" DAG using the namespace prefix
- [x] Adjust the `index` task so that an empty string in the config YAML file is considered null for the purposes of whether to use a cell file or not.
- [x] Switch to just copying the stored geometry in `mrxv` when running the `fetch_geom` task. Using `psgeom` outputs a geometry version which is slightly incorrect for the format required by CrystFEL (at least currently)
- [x] Handle the case with some empty runs which was crashing the `stream_analysis` task 

Notes
---------
- Rayonix geometries need to be deployed. This should be done by hutch staff ideally using `geometry_deploy_constants`
  - The Rayonix is not handled by `makepeds` so this is a separate additional step.
- Either `fetch_mask` and `fetch_geom` need to be run separately, or the `setup_metrology` DAG needs to be run. Ideally this should be handled internally in the future, instead of having to remember to do this step as well.
-  Does the config YAML need to have the `dataset` field modfied for `fetch_mask` depending on the detector used? I left a comment to say that. These sorts of procedures should also be automated in the future to avoid issues.
- **Full `process_sfx` workflow takes on the order of 10-15 minutes** for **120 cores**
  - Not great. One would hope portions of this could be brought down. It's possible that not much more can be done for certain tasks, however.