### PR TITLE
Hotfix mfxl1025422

### DIFF
--- a/btx/diagnostics/geoptimizer.py
+++ b/btx/diagnostics/geoptimizer.py
@@ -119,7 +119,7 @@ class Geoptimizer:
                                geom=gfile, cell=cell_file, int_rad=params.int_radius, methods=params.methods, tolerance=params.tolerance, no_revalidate=params.no_revalidate, 
                                multi=params.multi, profile=params.profile, queue=self.queue, ncores=params.get('ncores') if params.get('ncores') is not None else 64,
                                time=params.get('time') if params.get('time') is not None else '1:00:00',
-                               slurm_account=self.slurm_account, slurm_reservation=self.slurm_reservation)
+                               slurm_account=self.slurm_account, slurm_reservation=self.slurm_reservation, wait=False)
                 idxr.tmp_exe = jobfile
                 idxr.stream = stream
                 idxr.launch(addl_command=f"echo {jobname} | tee -a {statusfile}\n",
@@ -159,7 +159,8 @@ class Geoptimizer:
                                    cell_ref=params.get('ref_cell'),
                                    addl_command=f"echo {jobname} | tee -a {statusfile}\n",
                                    slurm_account=self.slurm_account,
-                                   slurm_reservation=self.slurm_reservation
+                                   slurm_reservation=self.slurm_reservation,
+                                   wait=False
             )
             jobnames.append(jobname)
             time.sleep(self.frequency)
@@ -207,7 +208,7 @@ class Geoptimizer:
                                          highres=params.get('highres'), 
                                          xds_style=False)
             stream_to_mtz.js.write_main(f"echo {jobname} | tee -a {statusfile}\n")
-            stream_to_mtz.launch()
+            stream_to_mtz.launch(wait=False)
 
             jobnames.append(jobname)
             time.sleep(self.frequency)

--- a/btx/interfaces/ischeduler.py
+++ b/btx/interfaces/ischeduler.py
@@ -140,10 +140,14 @@ class JobScheduler:
         with open(self.jobfile, 'a') as jfile:
             jfile.write(application.replace("python", pythonpath))
 
-    def submit(self):
+    def submit(self, wait=True):
         """ Submit to queue. """
-        os.system(f"sbatch -W {self.jobfile}")
-        logger.info(f"sbatch -W {self.jobfile}")
+        if wait:
+            os.system(f"sbatch -W {self.jobfile}")
+            logger.info(f"sbatch -W {self.jobfile}")
+        else:
+            os.system(f"sbatch {self.jobfile}")
+            logger.info(f"sbatch {self.jobfile}")
 
     def clean_up(self):
         """ Add a line to delete submission file."""

--- a/btx/interfaces/istream.py
+++ b/btx/interfaces/istream.py
@@ -594,7 +594,7 @@ def cluster_cell_params(cell, out_clusters, out_cell, in_cell=None, eps=5, min_s
 
 def launch_stream_analysis(in_stream, out_stream, fig_dir, tmp_exe, queue, ncores, 
                            cell_only=False, cell_out=None, cell_ref=None, addl_command=None,
-                           slurm_account="lcls", slurm_reservation=""):
+                           slurm_account="lcls", slurm_reservation="", wait=True):
                            
     """
     Launch stream analysis task using iScheduler.
@@ -648,7 +648,7 @@ def launch_stream_analysis(in_stream, out_stream, fig_dir, tmp_exe, queue, ncore
     if addl_command is not None:
         js.write_main(f"{addl_command}\n")
     js.clean_up()
-    js.submit()
+    js.submit(wait=wait)
 
 def get_most_recent_run(streams: list) -> int:
     """ From a list of stream files, get the most recent run.

--- a/btx/processing/indexer.py
+++ b/btx/processing/indexer.py
@@ -18,7 +18,7 @@ class Indexer:
     def __init__(self, exp, run, det_type, tag, taskdir, geom, cell=None, int_rad='4,5,6', methods='mosflm',
                  tolerance='5,5,5,1.5', tag_cxi=None, no_revalidate=True, multi=True, profile=True,
                  ncores=64, queue='milano', time='1:00:00', *, mpi_init = False, slurm_account="lcls",
-                 slurm_reservation=""):
+                 slurm_reservation="", wait=True):
 
         if mpi_init:
             from mpi4py import MPI
@@ -54,6 +54,7 @@ class Indexer:
         self.slurm_account = slurm_account
         self.slurm_reservation = slurm_reservation
         self._retrieve_paths()
+        self.wait = wait
 
     def _retrieve_paths(self):
         """
@@ -107,7 +108,7 @@ class Indexer:
         js.write_header()
         js.write_main(command, dependencies=['crystfel'] + self.methods.split(','))
         js.clean_up()
-        js.submit()
+        js.submit(wait=self.wait)
         logger.info(f"Indexing executable submitted: {self.tmp_exe}")
 
     @property

--- a/btx/processing/merge.py
+++ b/btx/processing/merge.py
@@ -176,12 +176,12 @@ class StreamtoMtz:
                 command += f" --highres={highres}"
             self.js.write_main(f"{command}\n")        
 
-    def launch(self):
+    def launch(self, wait=True):
         """
         Write an indexing executable for submission to slurm.
         """   
         self.js.clean_up()
-        self.js.submit()
+        self.js.submit(wait=wait)
 
     def merge_summary(self,
                       foms: list = ['CCstar', 'Rsplit'],

--- a/btx/processing/merge.py
+++ b/btx/processing/merge.py
@@ -20,7 +20,7 @@ class StreamtoMtz:
     """
     
     def __init__(self, input_stream, symmetry, taskdir, cell, ncores=16, queue='milano', tmp_exe=None, mtz_dir=None, anomalous=False,
-                 mpi_init=False, slurm_account="lcls", slurm_reservation=""):
+                 mpi_init=False, slurm_account="lcls", slurm_reservation="", slurm_time="0:30:00"):
         self.stream = input_stream # file of unmerged reflections, str
         self.symmetry = symmetry # point group symmetry, str
         self.taskdir = taskdir # path for storing output, str
@@ -29,6 +29,7 @@ class StreamtoMtz:
         self.queue = queue # cluster to submit job to
         self.slurm_account = slurm_account
         self.slurm_reservation = slurm_reservation
+        self.slurm_time = slurm_time
         self.mtz_dir = mtz_dir # directory to which to transfer mtz
         self.anomalous = anomalous # whether to separate Bijovet pairs
         self._set_up(tmp_exe)
@@ -65,7 +66,7 @@ class StreamtoMtz:
             tmp_exe = os.path.join(self.taskdir ,f'merge.sh')
         self.js = JobScheduler(tmp_exe, ncores=self.ncores, jobname=f'merge',
                                queue=self.queue, account=self.slurm_account,
-                               reservation=self.slurm_reservation)
+                               reservation=self.slurm_reservation, time=self.slurm_time)
         self.js.write_header()
 
         # retrieve paths

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -312,7 +312,8 @@ def merge(config):
                                 ncores=task.get('ncores') if task.get('ncores') is not None else 16,
                                 mtz_dir=os.path.join(setup.root_dir, "solve", f"{task.tag}"),
                                 anomalous=task.get('anomalous') if task.get('anomalous') is not None else False,
-                                slurm_account=setup.account, slurm_reservation=setup.reservation)
+                                slurm_account=setup.account, slurm_reservation=setup.reservation,
+                                slurm_time=task.get('time') if task.get('time') is not None else "0:30:00")
     stream_to_mtz.cmd_partialator(iterations=task.iterations, model=task.model,
                                   min_res=task.get('min_res'), push_res=task.get('push_res'), max_adu=task.get('max_adu'))
     for ns in [1, task.nshells]:


### PR DESCRIPTION
A few features were added based on the needs met during this experiment:
- providing the SLURM time limit as an argument for the `merge` task.
- adding a `wait` Boolean argument to JobScheduler is necessary for the tasks that optimize geometry based on crystal merging statistics (`refine_geometry`, `refine_distance` and `refine_center`). `wait` is `True` by default for proper communication with Airflow but is set to `False` when the workflow management is handled internally.